### PR TITLE
Allow to specify external job files in ch.znerol.podman-dump label

### DIFF
--- a/bin/podman-dump
+++ b/bin/podman-dump
@@ -234,6 +234,44 @@ class JobConfig:
         return result
 
 
+class JobDirectory:
+    """
+    Represents a directory of named job templates.
+    """
+    log = logging.getLogger("JobDirectory")
+
+    jobdir: Path
+    jobmap: Optional[Mapping] = None
+
+    def __init__(self, jobdir: Optional[str] = None):
+        self.jobdir = Path(jobdir if jobdir else "/etc/podman-dump/jobs")
+
+    def jobs(self, name: str) -> Sequence[JobConfig]:
+        """
+        Return a list of jobs.
+        """
+
+        if self.jobmap is None:
+            self.jobmap = {}
+            if self.jobdir.is_dir():
+                for child in self.jobdir.iterdir():
+                    if child.suffix != ".json":
+                        continue
+                    with child.open() as instream:
+                        config = json.load(instream)
+                    if 'jobs' not in config:
+                        self.log.warning("Skipped %s, no jobs found in config", child)
+                        continue
+
+                    entries = config.get('jobs', [])
+                    self.jobmap[Path(child.stem).name] = (JobConfig(entry) for entry in entries)
+
+        if name not in self.jobmap:
+            self.log.warning("No config found for %s in %s", name, self.jobdir)
+
+        return self.jobmap.get(name, [])
+
+
 class Job:
     """
     Represents one dump job of a specific container
@@ -314,7 +352,7 @@ class PodmanContainer:
     def __str__(self):
         return f"Container(cid={self.cid}, name={self.name})"
 
-    def jobs(self) -> Sequence[Job]:
+    def jobs(self, directory: JobDirectory) -> Sequence[Job]:
         """
         Return a list of jobs.
         """
@@ -323,8 +361,15 @@ class PodmanContainer:
         ]
         output = subprocess.check_output(cmd, text=True)
         config = json.loads(output or "{}")
-        entries = config.get('jobs', [])
-        return (Job(self.name, self.cid, JobConfig(entry)) for entry in entries)
+        if 'jobsFrom' in config:
+            job_configs = directory.jobs(config['jobsFrom'])
+        elif 'jobs' in config:
+            job_configs = (JobConfig(entry) for entry in config['jobs'])
+        else:
+            self.log.warning("Skipped %s, neither jobsFrom nor jobs found in ch.znerol.podman-dump label", self)
+            job_configs = []
+
+        return (Job(self.name, self.cid, job_config) for job_config in job_configs)
 
 
 class PodmanSource:
@@ -411,6 +456,10 @@ def main(prog, args):
         help="Turn on verbose logging"
     )
     parser.add_argument(
+        "--jobdir", dest="jobdir",
+        help="Path of the directory with job definitions",
+    )
+    parser.add_argument(
         "--podman", dest="podman",
         help="Path of the podman binary",
     )
@@ -432,11 +481,12 @@ def main(prog, args):
     level = logging.DEBUG if options.verbose else logging.INFO
     logging.basicConfig(level=level)
 
+    jobdir = JobDirectory(jobdir=options.jobdir)
     source = PodmanSource(podman=options.podman, conmon=options.conmon)
 
     for container in source.containers():
         datestamp = datetime.now()
-        jobs = [job for job in container.jobs() if job.in_schedule(options.schedule)]
+        jobs = [job for job in container.jobs(jobdir) if job.in_schedule(options.schedule)]
         for job in jobs:
             job.dump(options.dumpdir, source, datestamp)
 

--- a/doc/podman-dump.1.rst
+++ b/doc/podman-dump.1.rst
@@ -4,7 +4,7 @@ podman-dump
 Synopsis
 --------
 
-**podman-dump** [*-p*] [*-v*] [*--podman PODMAN*] [*--conmon CONMON*] [*dumpdir*] [*schedule*]
+**podman-dump** [*-p*] [*-v*] [*--jobsdir JOBSDIR*] [*--podman PODMAN*] [*--conmon CONMON*] [*dumpdir*] [*schedule*]
 
 
 Description
@@ -31,6 +31,21 @@ following form:
           },
         ]
       }
+
+Alternatively, the ``ch.znerol.podman-dump`` label can contain a single
+``jobsFrom`` key which specifies a file to load from the directory specified in
+the ``--jobsdir`` argument. The directory defaults to ``/etc/podman-dump/jobs``.
+With the following configuration ``podman-dump`` would look for a jobs file in
+``/etc/podman-dump/jobs/postgres.json`` (Note: the extension must be present in
+the file path, but it must be absent from the ``jobsFrom`` key).
+
+.. code-block:: json
+
+      {
+         "jobsFrom": "postgres"
+      }
+
+
 
 Each job specification may include the following keys and values:
 

--- a/doc/podman-dump@.service.8.rst
+++ b/doc/podman-dump@.service.8.rst
@@ -34,6 +34,12 @@ Environment
    ``/var/backups/podman/%i`` when run in systemd ``system`` scope and
    ``~/.local/backups/podman/%i`` when run in ``user`` scope.
 
+.. envvar:: PODMAN_DUMP_JOBDIR
+
+   Path of the directory where job definitions are stored. Defaults to
+   ``/etc/podman-dump/jobs`` when run in systemd ``system`` scope and
+   ``~/.config/podman-dump/jobs`` when run in ``user`` scope.
+
 .. envvar:: PODMAN_DUMP_FLAGS
 
    Flags used when invoking ``podman-dump``.

--- a/lib/systemd/dropins/path-system.conf
+++ b/lib/systemd/dropins/path-system.conf
@@ -4,3 +4,7 @@
 # Path of the directory where dumps are stored.
 #
 Environment=PODMAN_DUMP_DIR=/var/backups/podman/%i
+
+# PODMAN_DUMP_JOBDIR
+# Path of the directory where job files are stored.
+Environment=PODMAN_DUMP_JOBDIR=/etc/podman-dump/jobs

--- a/lib/systemd/dropins/path-user.conf
+++ b/lib/systemd/dropins/path-user.conf
@@ -4,3 +4,7 @@
 # Path of the directory where dumps are stored.
 #
 Environment=PODMAN_DUMP_DIR=%h/.local/backups/podman/%i
+
+# PODMAN_DUMP_JOBDIR
+# Path of the directory where job files are stored.
+Environment=PODMAN_DUMP_JOBDIR=%h/.config/podman-dump/jobs

--- a/lib/systemd/podman-dump@.service
+++ b/lib/systemd/podman-dump@.service
@@ -5,6 +5,6 @@ Documentation=man:podman-dump
 [Service]
 ExecStartPre=/bin/mkdir -p ${PODMAN_DUMP_DIR}
 ExecStart=/usr/bin/env \
-    podman-dump $PODMAN_DUMP_FLAGS ${PODMAN_DUMP_DIR} %i
+    podman-dump --jobdir ${PODMAN_DUMP_JOBDIR} $PODMAN_DUMP_FLAGS ${PODMAN_DUMP_DIR} %i
 
 SyslogIdentifier=podman-dump


### PR DESCRIPTION
For more complicated job definitions or for job definitions which contain special characters, it is more convenient to maintain them as separate files instead of inlining the whole JSON into the label.

This PR adds a `--jobdir` command line argument. Job definitions in this directory may be referenced using the `jobsFrom` JSON key. The `jobs` list is then loaded from the specified file.